### PR TITLE
Add metadata to WSL

### DIFF
--- a/docs/developer-laptop-setup/mount-windows-drives-in-wsl.md
+++ b/docs/developer-laptop-setup/mount-windows-drives-in-wsl.md
@@ -11,5 +11,7 @@ The problem with this is some service such as Docker Compose volumes need the bi
     ```
     [automount]
     root = /
+    options = "metadata"
     ```
+    The options property allows WSL to change Windows file permissions
 1. Reboot machine for changes to take effect.


### PR DESCRIPTION
WSL is unable to change some Windows file permissions.  To correct this the wsl.conf file can be updated.