### PR TITLE
Reference Mac setup scripts

### DIFF
--- a/docs/local-development-setup/mac-setup-scripts.md
+++ b/docs/local-development-setup/mac-setup-scripts.md
@@ -1,7 +1,7 @@
 # Mac Setup Scripts
 Mac users may want to consider the use of [Homebrew](brew.sh) as their go-to package manager which simplifies the installation of many packages, desktop applications, command line tools etc. by using a single command for the majority of if not all installations.
 
-A set of scripts: ([dffc-mac-scripts](https://github.com/rtasalem/dffc-mac-scripts)) have been created and are free to use by anyone to aid setting up a Mac for the first time. These scripts cover mandatory installations that are listed within the FFC Development Guide including:
+A set of scripts: ([dffc-mac-scripts](https://github.com/rtasalem/dffc-mac-scripts)) have been created and are free to use by anyone to aid setting up a Mac for the first time. Please refer to the repository for full instructions. These scripts cover mandatory installations that are listed within the FFC Development Guide including:
 - Command Line Tools for Xcode
 - Homebrew
 - kubectl 

--- a/docs/local-development-setup/mac-setup-scripts.md
+++ b/docs/local-development-setup/mac-setup-scripts.md
@@ -1,2 +1,4 @@
 # Mac Setup Scripts
 Mac users may want to consider the use of [Homebrew](brew.sh) as a package manager which simplifies the installation of many packages, desktop applications, command line tools etc. by using a single command for the majority of installations.
+
+A set of scripts: [dffc-mac-scripts](https://github.com/rtasalem/dffc-mac-scripts), have been created and are free to use by anyone to aid setting up a Mac for the first time. These scripts cover mandatory installations that are listed within the FFC Development Guide as well as optional installs that are useful for day-to-day development and productivity.

--- a/docs/local-development-setup/mac-setup-scripts.md
+++ b/docs/local-development-setup/mac-setup-scripts.md
@@ -15,7 +15,7 @@ A set of scripts: ([dffc-mac-scripts](https://github.com/rtasalem/dffc-mac-scrip
 - detect-secrets
 - .NET SDK
 - Docker
-- Visual Studio Code. 
+- Visual Studio Code
 
 The scripts *do not* cover StandardJS or NVM (Node Version Manager). Please refer to the FFC Development Guide for instructions on installing StandardJS and NVM.
 

--- a/docs/local-development-setup/mac-setup-scripts.md
+++ b/docs/local-development-setup/mac-setup-scripts.md
@@ -1,4 +1,22 @@
 # Mac Setup Scripts
-Mac users may want to consider the use of [Homebrew](brew.sh) as a package manager which simplifies the installation of many packages, desktop applications, command line tools etc. by using a single command for the majority of installations.
+Mac users may want to consider the use of [Homebrew](brew.sh) as their go-to package manager which simplifies the installation of many packages, desktop applications, command line tools etc. by using a single command for the majority of if not all installations.
 
-A set of scripts: [dffc-mac-scripts](https://github.com/rtasalem/dffc-mac-scripts), have been created and are free to use by anyone to aid setting up a Mac for the first time. These scripts cover mandatory installations that are listed within the FFC Development Guide as well as optional installs that are useful for day-to-day development and productivity.
+A set of scripts: ([dffc-mac-scripts](https://github.com/rtasalem/dffc-mac-scripts)) have been created and are free to use by anyone to aid setting up a Mac for the first time. These scripts cover mandatory installations that are listed within the FFC Development Guide including:
+- Command Line Tools for Xcode
+- Homebrew
+- kubectl 
+- Azure CLI 
+- Helm
+- Snyk CLI
+- GitHub CLI
+- Python
+- Pip
+- pre-commit 
+- detect-secrets
+- .NET SDK
+- Docker
+- Visual Studio Code. 
+
+The scripts *do not* cover StandardJS or NVM (Node Version Manager). Please refer to the FFC Development Guide for instructions on installing StandardJS and NVM.
+
+There is also an optional script which installs a range of mostly desktop applications and other packages that are not mandatorty but are nonetheless useful for day-to-day development.

--- a/docs/local-development-setup/mac-setup-scripts.md
+++ b/docs/local-development-setup/mac-setup-scripts.md
@@ -1,0 +1,2 @@
+# Mac Setup Scripts
+Mac users may want to consider the use of [Homebrew](brew.sh) as a package manager which simplifies the installation of many packages, desktop applications, command line tools etc. by using a single command for the majority of installations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Add user to sudoers file: local-development-setup/setup-sudoers.md
     - macOs:
       - Setup command line tools: local-development-setup/setup-macos-command-line-tools.md
+      - Mac Setup Scripts: local-development-setup/mac-setup-scripts.md
     - Common:
       - Install Docker Desktop: local-development-setup/install-docker-desktop.md
       - Install Docker Compose: local-development-setup/install-docker-compose.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,7 @@ nav:
       - Install Windows Subsystem for Linux (WSL): local-development-setup/install-wsl.md
       - Update WSL configuration: local-development-setup/wsl.md
       - Add user to sudoers file: local-development-setup/setup-sudoers.md
-    - macOs:
+    - Mac:
       - Setup command line tools: local-development-setup/setup-macos-command-line-tools.md
       - Mac Setup Scripts: local-development-setup/mac-setup-scripts.md
     - Common:


### PR DESCRIPTION
Including a reference to Mac setup scripts for Mac users that can install the majority of software and packages listed in the FFC dev guide via Homebrew.

Scripts: https://github.com/rtasalem/dffc-mac-scripts
